### PR TITLE
Mixin to add appearance vendor prefixes.

### DIFF
--- a/toolkit.less
+++ b/toolkit.less
@@ -310,3 +310,24 @@
 	border-bottom-color: rgba(0,0,0,0);
 	border-right-width: 0;
 }
+
+
+
+/* ---------------------------------------------------------------------------
+
+	Toolkit: Appearance
+	===================
+	@since 0.0.2
+	
+	Appearance isn't supported by Autoprefixer.
+	
+	From Autoprefixer: "Unlike transition, the appearance property is not 
+	a part of any specification. So there is no appearance, only 
+	-moz-appearance and -webkit-appearance."
+
+--------------------------------------------------------------------------- */
+
+.appearance(@value: none) {
+	-webkit-appearance: @value;
+	-moz-appearance: @value;
+}


### PR DESCRIPTION
Appearance isn't supported by Autoprefixer. Propose adding a mixin to Toolkit and iterating the version number.

@MalucoMarinero, thoughts? 

It doesn't save a heap of time really. 
