### PR TITLE
Bug fix for strictMath mode breaking .to()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased Changes
 
+## 0.0.2 - 2014-11-15
+### Added
+- support for strictMath mode (un-necessary parenthesis)
+
 ## 0.0.1 - 2014-11-3
 ### Added
 - tint, shade, rem and em custom functions.

--- a/toolkit.less
+++ b/toolkit.less
@@ -45,7 +45,7 @@
 
 // Up to but not inclusive (1px less) the value:
 .to-mq(@unitlessPx, @rules) {
-	@ems: em(@unitlessPx - 1);
+	@ems: em( ( @unitlessPx - 1 ) );
 	@media screen and ( max-width: @ems ) {
 		@rules();
 	}
@@ -53,7 +53,7 @@
 
 .from-to-mq(@from, @to, @rules) {
 	@fromEms: em(@from);
-	@toEms: em( @to - 1 );
+	@toEms: em( ( @to - 1 ) );
 	@media screen and (min-width: @fromEms) and (max-width: @toEms) {
 		@rules();
 	}


### PR DESCRIPTION
Un-necessary parenthesis added. Propose a version number bump — let me know best practices re that, for now I've added what I think makes sense to the Change Log in a fork, I realise that's probably not ideal. 
